### PR TITLE
Fix grammatical errors in _docs

### DIFF
--- a/_docs/admin-ui/dashboard.md
+++ b/_docs/admin-ui/dashboard.md
@@ -15,7 +15,7 @@ You can use some string expressions that will be replaced with the corresponding
 
 ## Markdown widget
 
-This widget type has only a `content` field in it's settings that is a _markdown content_, the widget will simply display it. You can also use HTML syntax in markdown.
+This widget type has only a `content` field in its settings that is a _markdown content_, the widget will simply display it. You can also use HTML syntax in markdown.
 
 ## Query widget
 

--- a/_docs/field-indexing.md
+++ b/_docs/field-indexing.md
@@ -157,7 +157,7 @@ The following is a list of the properties that are indexed regardless of Field i
 - **AllText**: the concatenated text extract of Content Field values. Format of a text extract of a Field is defined by the type of IndexHandler (ie.: HyperLinkIndexHandler returns the hyperlink's href, target, text and title attributes' concatenation). This technical Field is analyzed by *StandardAnalyzer*, and query texts are interpreted as queries in this Field when no query Field is selected.
 - **Path**: (node.Path) path of the Content.
 - **ParentId**: (node.ParentId) id of the parent Content of the Content.
-- **IsLastDraft**: value indicating that Content is last public version and it's status is public (node.IsLastPublicVersion && node.Version.Status == VersionStatus.Approved).
+- **IsLastDraft**: value indicating that Content is the last public version and its status is public (node.IsLastPublicVersion && node.Version.Status == VersionStatus.Approved).
 - **IsLastPublic**: (node.IsLatestVersion) value indicating that the Content is the last version (version ID equals to the last minor version ID).
 
 ## for Developers

--- a/_docs/managing-documents-from-microsoft-office.md
+++ b/_docs/managing-documents-from-microsoft-office.md
@@ -155,7 +155,7 @@ You can not manage members directly from Word but you can still see who is avail
 
 Tasks are also important content of a workspace. You have full control on managing tasks in the current workspace within Office.
 
-You can set a task completed by clicking the checkbox next to it's title. An empty check box means that it's state is **Pending**. A checked task refers to a **Completed** task. In any other cases, you'll see a filled checkbox. Depending on the status of the task an icon is placed next to the checkbox to visualize it's state.
+You can set a task completed by clicking the checkbox next to its title. An empty check box means that its state is **Pending**. A checked task refers to a **Completed** task. In any other cases, you'll see a filled checkbox. Depending on the status of the task an icon is placed next to the checkbox to visualize its state.
 
 In the following table you can find the proper mappings between the fields of Task Content Type and Office's properties:
 

--- a/_docs/security-component.md
+++ b/_docs/security-component.md
@@ -136,7 +136,7 @@ context.MoveEntity(entityId, targetId);
 context.DeleteEntity(entityId);
 // modify the owner of the entity
 context.ModifyEntityOwner(entityId, ownerId);
-// check if the entity inherits permissions from it's parent
+// check if the entity inherits permissions from its parent
 context.IsEntityInherited(entityId);
 // Check if the entity actually exists. If it cannot be found, this method
 // performs a callback to the host application for the entity if necessary.

--- a/_docs/tutorials/how-to-use-jwt-in-sn-client-js.md
+++ b/_docs/tutorials/how-to-use-jwt-in-sn-client-js.md
@@ -72,7 +72,7 @@ To avoid CORS issues, we will redirect OData and Session Management requests fro
 
 ### Using the Repository as an injectable service
 
-To interact with a sensenet Repository, you have to use a *Repository* instance. There are predefined Repository configurations in the *sn-client-js* (like the default ``SnRepository`` that we will use, or ``Mocks.MockRepository`` for testing). If you want to write your components in a decoupled and testable way it's be a good idea to inject the *base* repository class, called ``Repository.BaseRepository`` into them.
+To interact with a sensenet Repository, you have to use a *Repository* instance. There are predefined Repository configurations in the *sn-client-js* (like the default ``SnRepository`` that we will use, or ``Mocks.MockRepository`` for testing). If you want to write your components in a decoupled and testable way it's a good idea to inject the *base* repository class, called ``Repository.BaseRepository`` into them.
 Next we have to configure Aurelia's DI to inject the right Repository.BaseRepository implementation at runtime. Open ``./src/main.ts`` file, and insert the following code before ``aurelia.start()``
 
 ```ts

--- a/_docs/versioning-and-approval.md
+++ b/_docs/versioning-and-approval.md
@@ -42,13 +42,13 @@ This method provides an extra line of defense for keeping mission critical conte
 
 ### Public visibility
 
-Vistors in general are only allowed to view last public versions of a content. This is controlled by the *Open minor* permissions: a user that does not possess the open minor permission for a content will only see the last public version of a content, and will never see any changes that correspond to a draft version or that are not yet approved.
+Vistors in general are only allowed to view the last public versions of a content. This is controlled by the *Open minor* permissions: a user who does not possess the open minor permission for a content will only see the last public version of a content, and will never see any changes that correspond to a draft version or that are not yet approved.
 The other important thing here to bear in mind is that if a document gets rejected it does not mean that the document is not visible for the public. It only means that the last version that was rejected will not be visible to the public. So for example:
 1. Set approval on a document library to true.
-2. Upload a document - it's state will be pending for approval (you can check it out on versions tab): only users with open minor permissions will be able to see it.
-3. Send it to approval using the approval workflow. If the approver rejects it, it still not be visible for the public - or users that have no open minor permissions. If the approver approves it, it will be visible for the public.
-4. Edit the document and make some modifications. It's state will be pending for approval once again. Users with no open minor permissions are able to see the document but not the latest modifications: that is they see the last public version, and not the one that is pending for approval.
-5. Send the document for approval. If the approver rejects it: users without open minor permission will still not be able to view the modifications that have been rejected: only the last public version. If the approver approves the document: users without open minor permissions will finally be able to see the modifications as well, because at the moment of approval the last (yet pending) version became the last public version.
+2. Upload a document - its state will be pending for approval (you can check it out on the versions tab): only users with open minor permissions will be able to see it.
+3. Send it to approval using the approval workflow. If the approver rejects it, it still won't be visible to the public - or users that have no open minor permissions. If the approver approves it, it will be visible to the public.
+4. Edit the document and make some modifications. Its state will be pending for approval once again. Users with no open minor permissions are able to see the document but not the latest modifications: that is they see the last public version, and not the one that is pending for approval.
+5. Send the document for approval. If the approver rejects it: users without open minor permission will still not be able to view the modifications that have been rejected: only the last public version will be visible. If the approver approves the document: users without open minor permissions will finally be able to see the modifications as well, because at the moment of approval the last (yet pending) version becomes the last public version.
 
 ### Content states
 

--- a/_posts/2018-08-22-docviewer.md
+++ b/_posts/2018-08-22-docviewer.md
@@ -36,11 +36,11 @@ I asked the participants to follow through these steps:
 3: Go to page 2 and 3 then go back to the top of the page
 4: Open the comment section
 5: Zoom in and out
-6: Rotate the page to the left and then back to it's original state
+6: Rotate the page to the left and then back to its original state
 
 
 ## Iteration
-After finishing the user tests I evaluated the answers and there was a few things that needed to be changed. First of all the left sidebar icon was very unfamiliar for most of the participants and had a hard time finding it, so I had to find a more straightforward icon. Most participants liked the comment function and said it would benefit them. Also most of the participants didn't liked that the rotate buttons were on the bottom of the page, so I moved it to the top navbar.
+After finishing the user tests I evaluated the answers and there were a few things that needed to be changed. First of all, the left sidebar icon was very unfamiliar for most of the participants and they had a hard time finding it, so I had to find a more straightforward icon. Most participants liked the comment function and said it would benefit them. Also, most of the participants didn't like that the rotate buttons were on the bottom of the page, so I moved them to the top navbar.
 
 ![Iteration](/img/posts/Docviewer_mockup.png "Iterated design")
 


### PR DESCRIPTION
I fixed several grammatical errors in the documentation and made some sentences easier to understand.