### PR TITLE
Update year inside the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -49,7 +49,7 @@
                 <a href="http://community.sensenet.com/releases/">Releases</a> |
                 <a href="{{ site.baseurl }}/privacy_policy" target="_blank">Privacy Policy</a>
             </div>
-            <div class="copyright">Copyright © 2017 SenseNet Inc.</div>
+            <div class="copyright">Copyright © 2019 SenseNet Inc.</div>
         </div>
         <div>
 </footer>


### PR DESCRIPTION
Current version of the site shows ```2017``` year in the footer. I updated it to ```2019``` inside my commit.