### PR TITLE
Fix mixed content warnings

### DIFF
--- a/_posts/2016-02-02-sn7-picker-under-the-hood.md
+++ b/_posts/2016-02-02-sn7-picker-under-the-hood.md
@@ -147,7 +147,7 @@ As I mentioned before, the main purpose of rewriting the picker was to provide d
 
 As you could have read in [previous blog posts](https://blog.sensenet.com/admin/post/2015/11/27/skin-system-revamp-in-sn7.aspx "previous blog posts"), we’re working hard to make everything skinnable in SN7. With the new picker you’ll be able to define your own modal window which allows you to use Bootstrap’s or Foundation’s modal widget. You can set your modal object as the $modal parameter of the picker plugin and use its open and close actions on picker callbacks. With the templates and buttons section you can add the framework related classes and markup to the parts of the picker to make it styleable with bootstrap or foundation or other ui libraries.
 
-![Foundation grid on tablet](http://download.sensenet.com/BlogPostImages/SN7CopyPicker/tabletfoundationgrid.png "Foundation grid on tablet")
+![Foundation grid on tablet](https://download.sensenet.com/BlogPostImages/SN7CopyPicker/tabletfoundationgrid.png "Foundation grid on tablet")
 
 
 
@@ -155,7 +155,7 @@ As you could have read in [previous blog posts](https://blog.sensenet.com/admin/
 
 As long as we build in KendoUI plugins into the picker, we’re able to use its templating in them. This allows you to customize the markup of a grid row or a thumbnail item through plugins ’templates’ config section. For now, there’re some limitations related to these templates because the grid and the thumbnail view uses and displays a limited number of Fields. Later, we will allow you to list the fields that you want to display and then you will be able to add fully custom templates with KendoUI’s templating syntax. Now you’re only able to add some additional classes and change the markup in a way you keep the Kendo variables.
 
-![Bootstrap grid on tablet](http://download.sensenet.com/BlogPostImages/SN7CopyPicker/tabletbootstrapthumb.png "Bootstrap grid on tablet")
+![Bootstrap grid on tablet](https://download.sensenet.com/BlogPostImages/SN7CopyPicker/tabletbootstrapthumb.png "Bootstrap grid on tablet")
 
 
 

--- a/_posts/2016-02-23-improving-the-portlet-structure-in-sn7.md
+++ b/_posts/2016-02-23-improving-the-portlet-structure-in-sn7.md
@@ -32,7 +32,7 @@ Based on the nature of the research we determined the test-conditions by the fol
 -   Beside predefined Groups, users are allowed to take new Groups, as well
 -   We show users in advance the estimate time, how long the test will take them
 
-![Cards to sort](http://download.sensenet.com/BlogPostImages/CardSorting/cards.png, "Cards to sort")
+![Cards to sort](https://download.sensenet.com/BlogPostImages/CardSorting/cards.png "Cards to sort")
 
 ## Preparation
 
@@ -40,7 +40,7 @@ In accordance with the aim of research, namely classifying the structure, how Po
 
 We expect that the result of the unmoderated test, with the high number of participants will be as accurate as possible. Due to the number of Portlets in our existing system, we had to envolve a relatively high number of cards. Regarding to this fact, we asked users to share their comments on cards, and groups, wherever they deem it appropriate. This way information can be obtained about the background of their decisions. Also they were asked, if an unnecessary, unused or uncleaerly configured item is found among Cards, do not place them into functional Groups. Hopefully, by the end of this test we will see, which Portlets are the the most useful for developers and endusers, and we also want to know which ones are not in use at all, by our users of any qualification.
 
-![Card sorting Groups](http://download.sensenet.com/BlogPostImages/CardSorting/groups.png "Cards to sort")
+![Card sorting Groups](https://download.sensenet.com/BlogPostImages/CardSorting/groups.png "Cards to sort")
 
 Excited? [Take the test](https://ux.demo.sensenet.com/ "Take the test")!
 


### PR DESCRIPTION
From another PR:

https://github.com/SenseNet/sensenet.github.io/pull/315/checks?check_run_id=249526454


```
Mixed content detected
Although you have enabled HTTPS on your site, we’ve detected some content that’s still being served over an HTTP connection.

DETAILS
In blog/2016/02/02/sn7-picker-under-the-hood.html:

img http://download.sensenet.com/BlogPostImages/SN7CopyPicker/tabletfoundationgrid.png
img http://download.sensenet.com/BlogPostImages/SN7CopyPicker/tabletbootstrapthumb.png
In blog/2016/02/23/improving-the-portlet-structure-in-sn7.html:

img http://download.sensenet.com/BlogPostImages/CardSorting/cards.png,
img http://download.sensenet.com/BlogPostImages/CardSorting/groups.png
```