### PR TITLE
Center footer and home content in the tablet breakpoint

### DIFF
--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -6,6 +6,13 @@ footer {
     margin-top: 50px;
 }
 
+footer .container-narrow {
+    @media screen and (max-width: 1100px) and (min-width: 800px) {
+        margin-right: auto;
+        margin-left: auto;
+    }
+}
+
 footer .footer-logo {
     position: absolute;
     left: 50%;

--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -12,6 +12,13 @@
     margin-bottom: 50px;
 }
 
+.home .container-narrow {
+    @media screen and (max-width: 1100px) and (min-width: 800px) {
+        margin-right: auto;
+        margin-left: auto;
+    }
+}
+
 .home .intro {
     text-align: center;
 }


### PR DESCRIPTION
The main container ```.container-narrow``` (https://github.com/SenseNet/sensenet.github.io/blob/master/_sass/_base.scss#L45) is moved to the right to leave room for the left sidebar in tablet (between 800px and 1100px), but it also moves the content of the footer and the home content (which don't interact with it).

This pr tries to fix that issue.

Before:
<img width="1095" alt="Screen Shot 2019-10-07 at 12 08 00 AM" src="https://user-images.githubusercontent.com/2272928/66286680-1d8d8e00-e898-11e9-99af-bbcc356430c4.png">

After:
<img width="1095" alt="Screen Shot 2019-10-07 at 12 08 12 AM" src="https://user-images.githubusercontent.com/2272928/66286687-23836f00-e898-11e9-8a02-c3eab36260c2.png">
