### PR TITLE
Edit Facebook links for sense/net CMS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,8 @@ email: snteam@sensenet.com
 description: 'sensenet Community Website'
 twitter:
     username: sensenet
+facebook:
+    facebook: sensenetcms
 github_username: SenseNet
 author: SenseNet
 future: true
@@ -45,6 +47,7 @@ social:
     name: Sense/Net
     links:
         - https://twitter.com/sensenet
+        - https://www.facebook.com/sensenetcms
         - https://www.linkedin.com/company/sense-net-inc
         - https://plus.google.com/+Sensenet
         - https://github.com/SenseNet

--- a/_config.yml
+++ b/_config.yml
@@ -3,8 +3,6 @@ email: snteam@sensenet.com
 description: 'sensenet Community Website'
 twitter:
     username: sensenet
-facebook:
-    facebook: sensenetcms
 github_username: SenseNet
 author: SenseNet
 future: true
@@ -47,7 +45,6 @@ social:
     name: Sense/Net
     links:
         - https://twitter.com/sensenet
-        - https://www.facebook.com/sensenetcms
         - https://www.linkedin.com/company/sense-net-inc
         - https://plus.google.com/+Sensenet
         - https://github.com/SenseNet

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ description: 'sensenet Community Website'
 twitter:
     username: sensenet
 facebook:
-    facebook: sensenetcms
+    facebook: sensenetcsp
 github_username: SenseNet
 author: SenseNet
 future: true
@@ -47,7 +47,7 @@ social:
     name: Sense/Net
     links:
         - https://twitter.com/sensenet
-        - https://www.facebook.com/sensenetcms
+        - https://www.facebook.com/sensenetcsp
         - https://www.linkedin.com/company/sense-net-inc
         - https://plus.google.com/+Sensenet
         - https://github.com/SenseNet

--- a/_data/awesome-readme.md
+++ b/_data/awesome-readme.md
@@ -78,7 +78,6 @@
 - [Community site](http://community.sensenet.com)
 - [sensenet Blog](http://community.sensenet.com/blog/)
 - [Stack Overflow](http://stackoverflow.com/questions/tagged/sensenet)
-- [Facebook](https://www.facebook.com/sensenetcms)
 - [Twitter](https://twitter.com/sensenet)
 - [Gitter](https://gitter.im/SenseNet)
 

--- a/_data/awesome-readme.md
+++ b/_data/awesome-readme.md
@@ -78,6 +78,7 @@
 - [Community site](http://community.sensenet.com)
 - [sensenet Blog](http://community.sensenet.com/blog/)
 - [Stack Overflow](http://stackoverflow.com/questions/tagged/sensenet)
+- [Facebook](https://www.facebook.com/sensenetcms)
 - [Twitter](https://twitter.com/sensenet)
 - [Gitter](https://gitter.im/SenseNet)
 

--- a/_data/awesome-readme.md
+++ b/_data/awesome-readme.md
@@ -78,7 +78,7 @@
 - [Community site](http://community.sensenet.com)
 - [sensenet Blog](http://community.sensenet.com/blog/)
 - [Stack Overflow](http://stackoverflow.com/questions/tagged/sensenet)
-- [Facebook](https://www.facebook.com/sensenetcms)
+- [Facebook](https://www.facebook.com/sensenetcsp)
 - [Twitter](https://twitter.com/sensenet)
 - [Gitter](https://gitter.im/SenseNet)
 

--- a/_data/awesome-sensenet.json
+++ b/_data/awesome-sensenet.json
@@ -182,7 +182,7 @@
   },
   {
     "name": "Facebook",
-    "href": "https://www.facebook.com/sensenetcms",
+    "href": "https://www.facebook.com/sensenetcsp",
     "category": "community"
   },
   {

--- a/_data/awesome-sensenet.json
+++ b/_data/awesome-sensenet.json
@@ -181,11 +181,6 @@
     "category": "community"
   },
   {
-    "name": "Facebook",
-    "href": "https://www.facebook.com/sensenetcms",
-    "category": "community"
-  },
-  {
     "name": "Twitter",
     "href": "https://twitter.com/sensenet",
     "category": "community"

--- a/_data/awesome-sensenet.json
+++ b/_data/awesome-sensenet.json
@@ -181,6 +181,11 @@
     "category": "community"
   },
   {
+    "name": "Facebook",
+    "href": "https://www.facebook.com/sensenetcms",
+    "category": "community"
+  },
+  {
     "name": "Twitter",
     "href": "https://twitter.com/sensenet",
     "category": "community"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,7 +30,6 @@
                     <li><a href="https://github.com/SenseNet/awesome-sensenet">Awesome SenseNet</a></li>
                     <li><a href="https://stackoverflow.com/questions/tagged/sensenet">Stackoverflow</a></li>
                     <li><a href="https://gitter.im/SenseNet/sensenet">Gitter</a></li>
-                    <li><a href="https://www.facebook.com/sensenetcms/">Facebook</a></li>
                     <li><a href="https://twitter.com/sensenet">Twitter</a></li>
                 </ul>
             </section>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,6 +30,7 @@
                     <li><a href="https://github.com/SenseNet/awesome-sensenet">Awesome SenseNet</a></li>
                     <li><a href="https://stackoverflow.com/questions/tagged/sensenet">Stackoverflow</a></li>
                     <li><a href="https://gitter.im/SenseNet/sensenet">Gitter</a></li>
+                    <li><a href="https://www.facebook.com/sensenetcms/">Facebook</a></li>
                     <li><a href="https://twitter.com/sensenet">Twitter</a></li>
                 </ul>
             </section>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,7 +30,7 @@
                     <li><a href="https://github.com/SenseNet/awesome-sensenet">Awesome SenseNet</a></li>
                     <li><a href="https://stackoverflow.com/questions/tagged/sensenet">Stackoverflow</a></li>
                     <li><a href="https://gitter.im/SenseNet/sensenet">Gitter</a></li>
-                    <li><a href="https://www.facebook.com/sensenetcms/">Facebook</a></li>
+                    <li><a href="https://www.facebook.com/sensenetcsp/">Facebook</a></li>
                     <li><a href="https://twitter.com/sensenet">Twitter</a></li>
                 </ul>
             </section>

--- a/_pages/contact.html
+++ b/_pages/contact.html
@@ -37,8 +37,8 @@ layout: default
                 <p>Share your feedbacks or quick questions about SenseNet components chatting with us on <a href="https://gitter.im/SenseNet/sensenet">Gitter</a></p>
             </li>
             <li>
-                <h2><i class="fa fa-facebook" aria-hidden="true"></i>Facebook and <i class="fa fa-twitter" aria-hidden="true"></i>Twitter</h2>
-                <p>For the latest news about sensenet, like us on <a href="https://www.facebook.com/sensenetcms/">Facebook</a> and follow <a href="https://twitter.com/sensenet">@sensenet</a> on Twitter.</p>
+                <h2><i class="fa fa-twitter" aria-hidden="true"></i>Twitter</h2>
+                <p>For the latest news about sensenet, follow <a href="https://twitter.com/sensenet">@sensenet</a> on Twitter.</p>
             </li>
             <li>
                 <h2>For Enterprise Customers</h2>

--- a/_pages/contact.html
+++ b/_pages/contact.html
@@ -37,8 +37,8 @@ layout: default
                 <p>Share your feedbacks or quick questions about SenseNet components chatting with us on <a href="https://gitter.im/SenseNet/sensenet">Gitter</a></p>
             </li>
             <li>
-                <h2><i class="fa fa-twitter" aria-hidden="true"></i>Twitter</h2>
-                <p>For the latest news about sensenet, follow <a href="https://twitter.com/sensenet">@sensenet</a> on Twitter.</p>
+                <h2><i class="fa fa-facebook" aria-hidden="true"></i>Facebook and <i class="fa fa-twitter" aria-hidden="true"></i>Twitter</h2>
+                <p>For the latest news about sensenet, like us on <a href="https://www.facebook.com/sensenetcms/">Facebook</a> and follow <a href="https://twitter.com/sensenet">@sensenet</a> on Twitter.</p>
             </li>
             <li>
                 <h2>For Enterprise Customers</h2>

--- a/_pages/contact.html
+++ b/_pages/contact.html
@@ -38,7 +38,7 @@ layout: default
             </li>
             <li>
                 <h2><i class="fa fa-facebook" aria-hidden="true"></i>Facebook and <i class="fa fa-twitter" aria-hidden="true"></i>Twitter</h2>
-                <p>For the latest news about sensenet, like us on <a href="https://www.facebook.com/sensenetcms/">Facebook</a> and follow <a href="https://twitter.com/sensenet">@sensenet</a> on Twitter.</p>
+                <p>For the latest news about sensenet, like us on <a href="https://www.facebook.com/sensenetcsp/">Facebook</a> and follow <a href="https://twitter.com/sensenet">@sensenet</a> on Twitter.</p>
             </li>
             <li>
                 <h2>For Enterprise Customers</h2>

--- a/_posts/2017-05-31-product-goals.md
+++ b/_posts/2017-05-31-product-goals.md
@@ -33,7 +33,6 @@ The team wanted to know if we were developing the right features for the right s
   [80c6156c]: nuget.org/profiles/sensenet "sensenet Nuget"
   [ffdb2e87]: https://www.npmjs.com/org/sensenet "sensenet on npm"
   [0c3b4e3a]: https://twitter.com/sensenet "Twitter"
-  [b175e3d7]: https://www.facebook.com/sensenetcms/ "sensenet on Facebook"
 
 Follow us on [Twitter][0c3b4e3a], like us on [Facebook][b175e3d7], or [clone the repository][bebd2231] and we'll need to check on our stats. We'll hate that (not really, so please, be a good champ).
 

--- a/_posts/2017-05-31-product-goals.md
+++ b/_posts/2017-05-31-product-goals.md
@@ -33,7 +33,7 @@ The team wanted to know if we were developing the right features for the right s
   [80c6156c]: nuget.org/profiles/sensenet "sensenet Nuget"
   [ffdb2e87]: https://www.npmjs.com/org/sensenet "sensenet on npm"
   [0c3b4e3a]: https://twitter.com/sensenet "Twitter"
-  [b175e3d7]: https://www.facebook.com/sensenetcms/ "sensenet on Facebook"
+  [b175e3d7]: https://www.facebook.com/sensenetcsp/ "sensenet on Facebook"
 
 Follow us on [Twitter][0c3b4e3a], like us on [Facebook][b175e3d7], or [clone the repository][bebd2231] and we'll need to check on our stats. We'll hate that (not really, so please, be a good champ).
 

--- a/_posts/2017-05-31-product-goals.md
+++ b/_posts/2017-05-31-product-goals.md
@@ -33,6 +33,7 @@ The team wanted to know if we were developing the right features for the right s
   [80c6156c]: nuget.org/profiles/sensenet "sensenet Nuget"
   [ffdb2e87]: https://www.npmjs.com/org/sensenet "sensenet on npm"
   [0c3b4e3a]: https://twitter.com/sensenet "Twitter"
+  [b175e3d7]: https://www.facebook.com/sensenetcms/ "sensenet on Facebook"
 
 Follow us on [Twitter][0c3b4e3a], like us on [Facebook][b175e3d7], or [clone the repository][bebd2231] and we'll need to check on our stats. We'll hate that (not really, so please, be a good champ).
 


### PR DESCRIPTION
Closes #379 

It appears that the Sense/Net Facebook group/page is closed, so this PR removes the dead links to the Facebook page across the entire site. :+1: :smile:  :blue_book: 