### PR TITLE
Add icons for twitter, facebook and stackoverflow in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,10 +28,10 @@
                 <h5>Community</h5>
                 <ul class="community-menu">
                     <li><a href="https://github.com/SenseNet/awesome-sensenet">Awesome SenseNet</a></li>
-                    <li><a href="https://stackoverflow.com/questions/tagged/sensenet">Stackoverflow</a></li>
                     <li><a href="https://gitter.im/SenseNet/sensenet">Gitter</a></li>
-                    <li><a href="https://www.facebook.com/sensenetcsp/">Facebook</a></li>
-                    <li><a href="https://twitter.com/sensenet">Twitter</a></li>
+                    <li><a href="https://stackoverflow.com/questions/tagged/sensenet"><i class="fa fa-stackoverflow" aria-hidden="true"> Stackoverflow</i></a></li>
+                    <li><a href="https://www.facebook.com/sensenetcsp/"><i class="fa fa-facebook" aria-hidden="true"> Facebook</i></a></li>
+                    <li><a href="https://twitter.com/sensenet"><i class="fa fa-twitter" aria-hidden="true"> Twitter</i></a></li>
                 </ul>
             </section>
         </nav>


### PR DESCRIPTION
Previously:
![image](https://user-images.githubusercontent.com/18033169/67569445-38cd1a00-f72f-11e9-8580-912603bc4fb3.png)

This pull request:
![image](https://user-images.githubusercontent.com/18033169/67569456-3f5b9180-f72f-11e9-8ac3-7939b8bc67d8.png)

I could not add for Gitter because the css specified for Gitter in _sass/_icons.scss is incompatible with the other icons.